### PR TITLE
feat: add elixir code generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,6 @@ jobs:
   rust-check:
     needs: [codegen-check]
     uses: ./.github/workflows/rust-check.yaml
+  elixir-check:
+    needs: [codegen-check]
+    uses: ./.github/workflows/elixir-check.yaml

--- a/.github/workflows/codegen-check.yaml
+++ b/.github/workflows/codegen-check.yaml
@@ -27,6 +27,6 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Generate code
-        run: make all
+        run: make install --always-make
       - name: Check diff in generated code
         run: ./scripts/check_diff.sh

--- a/.github/workflows/codegen-check.yaml
+++ b/.github/workflows/codegen-check.yaml
@@ -26,6 +26,14 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '26'
+          elixir-version: '1.15.7'
+      - name: Install elixir protobuf compiler
+        run: |
+          mix escript.install hex protobuf --force
+          echo "$HOME/.mix/escripts" >> "$GITHUB_PATH"
       - name: Generate code
         run: make install --always-make
       - name: Check diff in generated code

--- a/.github/workflows/elixir-check.yaml
+++ b/.github/workflows/elixir-check.yaml
@@ -1,0 +1,36 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+permissions:
+  contents: read
+on:
+  workflow_call:
+
+defaults:
+  run:
+    working-directory: elixir/edgehog_device_forwarder_proto
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '26'
+          elixir-version: '1.15.7'
+      - name: Fetch dependencies
+        run: mix do deps.get --only test, deps.compile
+      - name: Check formatting
+        run: mix format --check-formatted
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '26'
+          elixir-version: '1.15.7'
+      - name: Fetch dependencies
+        run: mix do deps.get --only test, deps.compile
+      - name: Run tests
+        run:  mix test

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,3 +5,7 @@ Source: https://github.com/edgehog-device-manager/edgehog-device-forwarder-proto
 Files: out/* rust/Cargo.lock rust/edgehog-device-forwarder-proto/src/proto.rs
 Copyright: 2023 SECO Mind Srl
 License: Apache-2.0
+
+Files: elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/**/*.ex
+Copyright: 2023 SECO Mind Srl
+License: Apache-2.0

--- a/elixir/edgehog_device_forwarder_proto/.formatter.exs
+++ b/elixir/edgehog_device_forwarder_proto/.formatter.exs
@@ -1,0 +1,7 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:protobuf]
+]

--- a/elixir/edgehog_device_forwarder_proto/.gitignore
+++ b/elixir/edgehog_device_forwarder_proto/.gitignore
@@ -1,0 +1,29 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+edgehog_device_forwarder_proto-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/elixir/edgehog_device_forwarder_proto/README.md
+++ b/elixir/edgehog_device_forwarder_proto/README.md
@@ -1,0 +1,25 @@
+<!--
+  Copyright 2023 SECO Mind Srl
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# EdgehogDeviceForwarderProto
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `edgehog_device_forwarder_proto` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:edgehog_device_forwarder_proto, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at <https://hexdocs.pm/edgehog_device_forwarder_proto>.

--- a/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto.ex
+++ b/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto.ex
@@ -1,0 +1,5 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarderProto do
+end

--- a/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/http.pb.ex
+++ b/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/http.pb.ex
@@ -1,0 +1,72 @@
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Request.HeadersEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Request do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:path, 1, type: :string)
+  field(:method, 2, type: :string)
+  field(:query_string, 3, type: :string, json_name: "queryString")
+
+  field(:headers, 4,
+    repeated: true,
+    type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Request.HeadersEntry,
+    map: true
+  )
+
+  field(:body, 5, type: :bytes)
+  field(:port, 6, type: :uint32)
+end
+
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Response.HeadersEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Response do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:status_code, 1, type: :uint32, json_name: "statusCode")
+
+  field(:headers, 2,
+    repeated: true,
+    type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Response.HeadersEntry,
+    map: true
+  )
+
+  field(:body, 3, type: :bytes)
+end
+
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  oneof(:message, 0)
+
+  field(:request_id, 1, type: :bytes, json_name: "requestId")
+
+  field(:request, 2,
+    type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Request,
+    oneof: 0
+  )
+
+  field(:response, 3,
+    type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Response,
+    oneof: 0
+  )
+end

--- a/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/message.pb.ex
+++ b/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/message.pb.ex
@@ -1,0 +1,10 @@
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Message do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  oneof(:protocol, 0)
+
+  field(:http, 1, type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http, oneof: 0)
+  field(:ws, 2, type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.WebSocket, oneof: 0)
+end

--- a/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/ws.pb.ex
+++ b/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/ws.pb.ex
@@ -1,0 +1,27 @@
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.WebSocket.Close do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:code, 1, type: :uint32)
+  field(:reason, 2, type: :string)
+end
+
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.WebSocket do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  oneof(:message, 0)
+
+  field(:socket_id, 1, type: :bytes, json_name: "socketId")
+  field(:text, 2, type: :string, oneof: 0)
+  field(:binary, 3, type: :bytes, oneof: 0)
+  field(:ping, 4, type: :bytes, oneof: 0)
+  field(:pong, 5, type: :bytes, oneof: 0)
+
+  field(:close, 6,
+    type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.WebSocket.Close,
+    oneof: 0
+  )
+end

--- a/elixir/edgehog_device_forwarder_proto/mix.exs
+++ b/elixir/edgehog_device_forwarder_proto/mix.exs
@@ -1,0 +1,28 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarderProto.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :edgehog_device_forwarder_proto,
+      version: "0.0.1",
+      elixir: "~> 1.15",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:protobuf, "~> 0.12"}
+    ]
+  end
+end

--- a/elixir/edgehog_device_forwarder_proto/mix.lock
+++ b/elixir/edgehog_device_forwarder_proto/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "protobuf": {:hex, :protobuf, "0.12.0", "58c0dfea5f929b96b5aa54ec02b7130688f09d2de5ddc521d696eec2a015b223", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "75fa6cbf262062073dd51be44dd0ab940500e18386a6c4e87d5819a58964dc45"},
+}

--- a/elixir/edgehog_device_forwarder_proto/mix.lock.license
+++ b/elixir/edgehog_device_forwarder_proto/mix.lock.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+SPDX-License-Identifier: Apache-2.0

--- a/elixir/edgehog_device_forwarder_proto/test/edgehog_device_forwarder_proto_test.exs
+++ b/elixir/edgehog_device_forwarder_proto/test/edgehog_device_forwarder_proto_test.exs
@@ -1,0 +1,22 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarderProtoTest do
+  use ExUnit.Case
+  alias EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.{Message, Http, WebSocket}
+  doctest EdgehogDeviceForwarderProto
+
+  test "encode and decode test" do
+    ws = %WebSocket{socket_id: <<>>, message: {:text, "some string"}}
+    assert ws == ws |> WebSocket.encode() |> WebSocket.decode()
+
+    http_response = %Http.Response{status_code: 200, headers: %{}, body: <<>>}
+    http = %Http{request_id: <<>>, message: {:response, http_response}}
+
+    assert http == http |> Http.encode() |> Http.decode()
+
+    message = %Message{protocol: {:ws, ws}}
+    assert message == message |> Message.encode() |> Message.decode()
+    assert {:ws, ^ws} = message |> Message.encode() |> Message.decode() |> Map.get(:protocol)
+  end
+end

--- a/elixir/edgehog_device_forwarder_proto/test/test_helper.exs
+++ b/elixir/edgehog_device_forwarder_proto/test/test_helper.exs
@@ -1,0 +1,4 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+ExUnit.start()

--- a/scripts/elixir_deps_check.sh
+++ b/scripts/elixir_deps_check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+PROTOC_GEN_ELIXIR_VERSION="0.12.0"
+version=$(protoc-gen-elixir --version)
+
+if [ "$version" != "$PROTOC_GEN_ELIXIR_VERSION" ]; then
+    echo "incompatible elixir-protobuf version: found \"$version\", \
+expected \"$PROTOC_GEN_ELIXIR_VERSION\"" >&2
+    exit 1
+fi


### PR DESCRIPTION
~add nix package and ci action for elixir code generation.~
~works the same way as the rust code generation.~

~depends on #4 (included here)~

adds elixir code generation and ci tests.
~there is also some minor refactor to #3~
there is also a fix to the ci where it would check the diff after a `make all`, but the build directory is gitignored so it would always pass.