### PR TITLE
feat(export): re-exporting prost

### DIFF
--- a/rust/edgehog-device-forwarder-proto/src/lib.rs
+++ b/rust/edgehog-device-forwarder-proto/src/lib.rs
@@ -4,3 +4,6 @@
 mod proto;
 
 pub use proto::*;
+
+// re-exporting dependencies
+pub use prost;


### PR DESCRIPTION
Re-exporting `prost` prevents the need to import it in the `edgehog-device-runtime`.