### PR TITLE
feat(https): add HTTPS as a Message protocol 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,9 @@ ELIXIR_DEPS_CHECK_SCRIPT=$(CANONICAL_CURDIR)/scripts/elixir_deps_check.sh
 
 ELIXIR_LANG=$(ELIXIR_BUILD_DIR)/edgehog/device/forwarder/http.pb.ex \
 	$(ELIXIR_BUILD_DIR)/edgehog/device/forwarder/ws.pb.ex \
-	$(ELIXIR_BUILD_DIR)/edgehog/device/forwarder/message.pb.ex
-ELIXIR_FILES="$(ELIXIR_LANG_LIB)/edgehog/device/forwarder/"{http,ws,message}.pb.ex
+	$(ELIXIR_BUILD_DIR)/edgehog/device/forwarder/message.pb.ex \
+	$(ELIXIR_BUILD_DIR)/edgehog/device/forwarder/https.pb.ex
+ELIXIR_FILES="$(ELIXIR_LANG_LIB)/edgehog/device/forwarder/"{http,https,ws,message}.pb.ex
 
 # This is our default rule, so must come first
 .PHONY: all

--- a/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/http.pb.ex
+++ b/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/http.pb.ex
@@ -24,6 +24,7 @@ defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Request do
 
   field(:body, 5, type: :bytes)
   field(:port, 6, type: :uint32)
+  field(:host, 7, proto3_optional: true, type: :string)
 end
 
 defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Response.HeadersEntry do

--- a/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/https.pb.ex
+++ b/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/https.pb.ex
@@ -1,0 +1,19 @@
+defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Https do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  oneof(:message, 0)
+
+  field(:request_id, 1, type: :bytes, json_name: "requestId")
+
+  field(:request, 3,
+    type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Request,
+    oneof: 0
+  )
+
+  field(:response, 4,
+    type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http.Response,
+    oneof: 0
+  )
+end

--- a/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/message.pb.ex
+++ b/elixir/edgehog_device_forwarder_proto/lib/edgehog_device_forwarder_proto/edgehog/device/forwarder/message.pb.ex
@@ -7,4 +7,5 @@ defmodule EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Message do
 
   field(:http, 1, type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http, oneof: 0)
   field(:ws, 2, type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.WebSocket, oneof: 0)
+  field(:https, 3, type: EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Https, oneof: 0)
 end

--- a/proto/edgehog/device/forwarder/http.proto
+++ b/proto/edgehog/device/forwarder/http.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 SECO Mind Srl
+// Copyright 2023,2026 SECO Mind Srl
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";
@@ -6,24 +6,26 @@ syntax = "proto3";
 package edgehog.device.forwarder;
 
 message Http {
-    bytes request_id = 1;
-    oneof message {
-        Request request = 2;
-        Response response = 3;
-    }
+  bytes request_id = 1;
 
-    message Request {
-        string path = 1;
-        string method = 2;
-        string query_string = 3;
-        map<string, string> headers = 4;
-        bytes body = 5;
-        uint32 port = 6;
-    }
+  oneof message {
+    Request request = 2;
+    Response response = 3;
+  }
 
-    message Response {
-        uint32 status_code = 1;
-        map<string, string> headers = 2;
-        bytes body = 3;
-    }
+  message Request {
+    string path = 1;
+    string method = 2;
+    string query_string = 3;
+    map<string, string> headers = 4;
+    bytes body = 5;
+    uint32 port = 6;
+    optional string host = 7;
+  }
+
+  message Response {
+    uint32 status_code = 1;
+    map<string, string> headers = 2;
+    bytes body = 3;
+  }
 }

--- a/proto/edgehog/device/forwarder/https.proto
+++ b/proto/edgehog/device/forwarder/https.proto
@@ -1,0 +1,17 @@
+// Copyright 2026 SECO Mind Srl
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package edgehog.device.forwarder;
+
+import "edgehog/device/forwarder/http.proto";
+
+message Https {
+  bytes request_id = 1;
+
+  oneof message {
+    Http.Request request = 3;
+    Http.Response response = 4;
+  }
+}

--- a/proto/edgehog/device/forwarder/message.proto
+++ b/proto/edgehog/device/forwarder/message.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 SECO Mind Srl
+// Copyright 2023,2026 SECO Mind Srl
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";
@@ -6,11 +6,13 @@ syntax = "proto3";
 package edgehog.device.forwarder;
 
 import "edgehog/device/forwarder/http.proto";
+import "edgehog/device/forwarder/https.proto";
 import "edgehog/device/forwarder/ws.proto";
 
 message Message {
-    oneof protocol {
-        Http http = 1;
-        WebSocket ws = 2;
-    }
+  oneof protocol {
+    Http http = 1;
+    WebSocket ws = 2;
+    Https https = 3;
+  }
 }

--- a/proto/edgehog/device/forwarder/ws.proto
+++ b/proto/edgehog/device/forwarder/ws.proto
@@ -6,18 +6,18 @@ syntax = "proto3";
 package edgehog.device.forwarder;
 
 message WebSocket {
-    bytes socket_id = 1;
+  bytes socket_id = 1;
 
-    oneof message {
-        string text = 2;
-        bytes binary = 3;
-        bytes ping = 4;
-        bytes pong = 5;
-        Close close = 6;
-    }
+  oneof message {
+    string text = 2;
+    bytes binary = 3;
+    bytes ping = 4;
+    bytes pong = 5;
+    Close close = 6;
+  }
 
-    message Close {
-        uint32 code = 1;
-        string reason = 2;
-    }
+  message Close {
+    uint32 code = 1;
+    string reason = 2;
+  }
 }


### PR DESCRIPTION
Use the same messages as the HTTP, while creating a new module. This
will let us add more fields in the future if needed.


Depends on #17 